### PR TITLE
Remove duplicate daemonset, replace boilerplate image url

### DIFF
--- a/helm_cnv2/templates/pan-cni-multus.yaml
+++ b/helm_cnv2/templates/pan-cni-multus.yaml
@@ -58,7 +58,7 @@ spec:
         # This container installs the pan CNI binaries
         # and CNI network config file on each node.
         - name: install-pan-cni
-          image: <your-private-registry-image-path>
+          image: "{{ .Values.cni.image }}:{{ .Values.cni.version }}"
           imagePullPolicy: Always
           command: ["/install-pan-cni.sh", "main"]
           lifecycle:
@@ -118,4 +118,4 @@ spec:
             # pan-ngfw-ds's "appinfo" and part of "pan-cni-ready" volumes
             path: /var/log/pan-appinfo
             type: DirectoryOrCreate
-{{- end-}}
+{{- end -}}

--- a/helm_cnv2/templates/pan-cni.yaml
+++ b/helm_cnv2/templates/pan-cni.yaml
@@ -1,3 +1,4 @@
+{{- if not (eq .Values.cluster.deployTo "native") }}
 # This manifest installs the pan install-cni container, as well
 # as the pan CNI plugin and config on
 # each master and worker node in a Kubernetes cluster.
@@ -137,4 +138,4 @@ spec:
             # pan-ngfw-ds's "appinfo" and part of "pan-cni-ready" volumes
             path: /var/log/pan-appinfo
             type: DirectoryOrCreate
-
+{{- end -}}


### PR DESCRIPTION
## Description

Remove duplicate daemonset created when deploying native.
Replace boilerplate image url.

## Motivation and Context

Allows helm template to be installed in a native install, without an error because 2 daemonsets with the same name are created. Also sets the image url, removing the syntax error due to the current boilerplate.

## How Has This Been Tested?
Ran it locally. It successfully installed the chart.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
