### PR TITLE
Allow setting storageClassName in .Values

### DIFF
--- a/helm_cnv2/templates/pan-cn-mgmt.yaml
+++ b/helm_cnv2/templates/pan-cn-mgmt.yaml
@@ -199,7 +199,7 @@ spec:
       # Enable this to use Local PVs, after deploying pan-local-storage 
       # storageclass and PVs (refer provided pan-cn-pv-local.yaml) and 
       # after creating the mount point on the host nodes for local PVs .
-      storageClassName: pan-local-storage
+      storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
       selector:
         matchLabels:
             pv: panlogs
@@ -225,7 +225,7 @@ spec:
       # Enable this to use Local PVs, after deploying pan-local-storage 
       # storageclass and PVs (refer provided pan-cn-pv-local.yaml) and 
       # after creating the mount point on the host nodes for local PVs .
-      storageClassName: pan-local-storage
+      storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
       selector:
         matchLabels:
             pv: panvarlog
@@ -249,7 +249,7 @@ spec:
       # Enable this to use Local PVs, after deploying pan-local-storage 
       # storageclass and PVs (refer provided pan-cn-pv-local.yaml) and 
       # after creating the mount point on the host nodes for local PVs .
-      storageClassName: pan-local-storage
+      storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
       selector:
         matchLabels:
             pv: panvarcores
@@ -273,7 +273,7 @@ spec:
       # Enable this to use Local PVs, after deploying pan-local-storage 
       # storageclass and PVs (refer provided pan-cn-pv-local.yaml) and 
       # after creating the mount point on the host nodes for local PVs .
-      storageClassName: pan-local-storage
+      storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
       selector:
         matchLabels:
             pv: panplugincfg
@@ -297,7 +297,7 @@ spec:
       # Enable this to use Local PVs, after deploying pan-local-storage 
       # storageclass and PVs (refer provided pan-cn-pv-local.yaml) and 
       # after creating the mount point on the host nodes for local PVs .
-      storageClassName: pan-local-storage
+      storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
       selector:
         matchLabels:
             pv: panconfig
@@ -321,7 +321,7 @@ spec:
       # Enable this to use Local PVs, after deploying pan-local-storage 
       # storageclass and PVs (refer provided pan-cn-pv-local.yaml) and 
       # after creating the mount point on the host nodes for local PVs .
-      storageClassName: pan-local-storage
+      storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
       selector:
         matchLabels:
             pv: panplugins

--- a/helm_cnv2/templates/pan-cn-pv-local.yaml
+++ b/helm_cnv2/templates/pan-cn-pv-local.yaml
@@ -15,7 +15,7 @@ metadata:
     type: local
     pv: panlogs
 spec:
-  storageClassName: pan-local-storage
+  storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
   persistentVolumeReclaimPolicy: Delete
   capacity:
     storage: 20Gi
@@ -46,7 +46,7 @@ metadata:
     type: local
     pv: panlogs
 spec:
-  storageClassName: pan-local-storage
+  storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
   persistentVolumeReclaimPolicy: Delete
   capacity:
     storage: 20Gi
@@ -77,7 +77,7 @@ metadata:
     type: local
     pv: panvarlog
 spec:
-  storageClassName: pan-local-storage
+  storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
   persistentVolumeReclaimPolicy: Delete
   capacity:
     storage: 20Gi
@@ -108,7 +108,7 @@ metadata:
     type: local
     pv: panvarlog
 spec:
-  storageClassName: pan-local-storage
+  storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
   persistentVolumeReclaimPolicy: Delete
   capacity:
     storage: 20Gi
@@ -139,7 +139,7 @@ metadata:
     type: local
     pv: panvarcores
 spec:
-  storageClassName: pan-local-storage
+  storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
   persistentVolumeReclaimPolicy: Delete
   capacity:
     storage: 2Gi
@@ -170,7 +170,7 @@ metadata:
     type: local
     pv: panvarcores
 spec:
-  storageClassName: pan-local-storage
+  storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
   persistentVolumeReclaimPolicy: Delete
   capacity:
     storage: 2Gi
@@ -201,7 +201,7 @@ metadata:
     type: local
     pv: panplugincfg
 spec:
-  storageClassName: pan-local-storage
+  storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
   persistentVolumeReclaimPolicy: Delete
   capacity:
     storage: 1Gi
@@ -232,7 +232,7 @@ metadata:
     type: local
     pv: panplugincfg
 spec:
-  storageClassName: pan-local-storage
+  storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
   persistentVolumeReclaimPolicy: Delete
   capacity:
     storage: 1Gi
@@ -263,7 +263,7 @@ metadata:
     type: local
     pv: panconfig
 spec:
-  storageClassName: pan-local-storage
+  storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
   persistentVolumeReclaimPolicy: Delete
   capacity:
     storage: 8Gi
@@ -294,7 +294,7 @@ metadata:
     type: local
     pv: panconfig
 spec:
-  storageClassName: pan-local-storage
+  storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
   persistentVolumeReclaimPolicy: Delete
   capacity:
     storage: 8Gi
@@ -325,7 +325,7 @@ metadata:
     type: local
     pv: panplugins
 spec:
-  storageClassName: pan-local-storage
+  storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
   persistentVolumeReclaimPolicy: Delete
   capacity:
     storage: 200Mi
@@ -356,7 +356,7 @@ metadata:
     type: local
     pv: panplugins
 spec:
-  storageClassName: pan-local-storage
+  storageClassName: {{ default "pan-local-storage" .Values.storageClassName }}
   persistentVolumeReclaimPolicy: Delete
   capacity:
     storage: 200Mi

--- a/helm_cnv2/templates/pan-cn-pv-manual.yaml
+++ b/helm_cnv2/templates/pan-cn-pv-manual.yaml
@@ -8,7 +8,7 @@ metadata:
     type: local
     pv: panlogs
 spec:
-  storageClassName: manual
+  storageClassName: {{ default "manual" .Values.storageClassName }}
   capacity:
     storage: 20Gi
   accessModes:
@@ -27,7 +27,7 @@ metadata:
     type: local
     pv: panlogs
 spec:
-  storageClassName: manual
+  storageClassName: {{ default "manual" .Values.storageClassName }}
   capacity:
     storage: 20Gi
   accessModes:
@@ -46,7 +46,7 @@ metadata:
     type: local
     pv: panvarlog
 spec:
-  storageClassName: manual
+  storageClassName: {{ default "manual" .Values.storageClassName }}
   capacity:
     storage: 20Gi
   accessModes:
@@ -65,7 +65,7 @@ metadata:
     type: local
     pv: panvarlog
 spec:
-  storageClassName: manual
+  storageClassName: {{ default "manual" .Values.storageClassName }}
   capacity:
     storage: 20Gi
   accessModes:
@@ -84,7 +84,7 @@ metadata:
     type: local
     pv: panvarcores
 spec:
-  storageClassName: manual
+  storageClassName: {{ default "manual" .Values.storageClassName }}
   capacity:
     storage: 2Gi
   accessModes:
@@ -103,7 +103,7 @@ metadata:
     type: local
     pv: panvarcores
 spec:
-  storageClassName: manual
+  storageClassName: {{ default "manual" .Values.storageClassName }}
   capacity:
     storage: 2Gi
   accessModes:
@@ -122,7 +122,7 @@ metadata:
     type: local
     pv: panplugincfg
 spec:
-  storageClassName: manual
+  storageClassName: {{ default "manual" .Values.storageClassName }}
   capacity:
     storage: 1Gi
   accessModes:
@@ -141,7 +141,7 @@ metadata:
     type: local
     pv: panplugincfg
 spec:
-  storageClassName: manual
+  storageClassName: {{ default "manual" .Values.storageClassName }}
   capacity:
     storage: 1Gi
   accessModes:
@@ -160,7 +160,7 @@ metadata:
     type: local
     pv: panconfig
 spec:
-  storageClassName: manual
+  storageClassName: {{ default "manual" .Values.storageClassName }}
   capacity:
     storage: 8Gi
   accessModes:
@@ -179,7 +179,7 @@ metadata:
     type: local
     pv: panconfig
 spec:
-  storageClassName: manual
+  storageClassName: {{ default "manual" .Values.storageClassName }}
   capacity:
     storage: 8Gi
   accessModes:
@@ -198,7 +198,7 @@ metadata:
     type: local
     pv: panplugins
 spec:
-  storageClassName: manual
+  storageClassName: {{ default "manual" .Values.storageClassName }}
   capacity:
     storage: 200Mi
   accessModes:
@@ -217,7 +217,7 @@ metadata:
     type: local
     pv: panplugins
 spec:
-  storageClassName: manual
+  storageClassName: {{ default "manual" .Values.storageClassName }}
   capacity:
     storage: 200Mi
   accessModes:

--- a/helm_cnv2/values.yaml
+++ b/helm_cnv2/values.yaml
@@ -7,6 +7,8 @@
 cluster:
   deployTo: 
 
+storageClassName:
+
 # Firewall tags
 firewall:
   failoverMode: failopen


### PR DESCRIPTION
## Description

Adds a .Values.storageClassName, which is then used to override the pan-local-storage/manual hardcoded values.

## Motivation and Context

Allows users to specify their own storage classes. For example, to use longhorn.

## How Has This Been Tested?

I ran it in my cluster and was able to get longhorn to provision the volumes.


## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
