### PR TITLE
Allow setting imagePullSecrets

### DIFF
--- a/helm_cnv1_10_0/templates/pan-cn-mgmt.yaml
+++ b/helm_cnv1_10_0/templates/pan-cn-mgmt.yaml
@@ -34,6 +34,10 @@ spec:
         app: pan-mgmt
         appname: pan-mgmt-sts
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: pan-mgmt-sa
       priorityClassName: system-node-critical
       #terminationGracePeriodSeconds: 60 //for graceful exit of prestop hook

--- a/helm_cnv1_10_0/templates/pan-cn-ngfw.yaml
+++ b/helm_cnv1_10_0/templates/pan-cn-ngfw.yaml
@@ -50,6 +50,10 @@ spec:
           k8s.v1.cni.cncf.io/networks: pan-cni
           {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       priorityClassName: system-cluster-critical
       # Minimize downtime during a rolling upgrade or deletion; Can tell Kubernetes
       # to do a "force deletion": 

--- a/helm_cnv1_10_0/templates/pan-cni.yaml
+++ b/helm_cnv1_10_0/templates/pan-cni.yaml
@@ -27,6 +27,10 @@ spec:
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true

--- a/helm_cnv1_10_0/values.yaml
+++ b/helm_cnv1_10_0/values.yaml
@@ -53,6 +53,7 @@ cni:
 # Non essential configs
 ############
 imagePullSecrets: []
+  # - name: myRegistryKeySecretName
 nameOverride: ""
 fullnameOverride: ""
 

--- a/helm_cnv1_10_1/templates/pan-cn-mgmt.yaml
+++ b/helm_cnv1_10_1/templates/pan-cn-mgmt.yaml
@@ -36,6 +36,10 @@ spec:
       annotations:
           paloaltonetworks.com/app: pan-mgmt
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: pan-mgmt-sa
       priorityClassName: system-node-critical
       #terminationGracePeriodSeconds: 60 //for graceful exit of prestop hook

--- a/helm_cnv1_10_1/templates/pan-cn-ngfw.yaml
+++ b/helm_cnv1_10_1/templates/pan-cn-ngfw.yaml
@@ -34,6 +34,10 @@ spec:
           k8s.v1.cni.cncf.io/networks: pan-cni
           {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       priorityClassName: system-cluster-critical
       # Minimize downtime during a rolling upgrade or deletion; Can tell Kubernetes
       # to do a "force deletion": 

--- a/helm_cnv1_10_1/templates/pan-cni.yaml
+++ b/helm_cnv1_10_1/templates/pan-cni.yaml
@@ -40,6 +40,10 @@ spec:
         {{- end }}
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true

--- a/helm_cnv1_10_1/values.yaml
+++ b/helm_cnv1_10_1/values.yaml
@@ -53,6 +53,7 @@ cni:
 # Non essential configs
 ############
 imagePullSecrets: []
+  # - name: myRegistryKeySecretName
 nameOverride: ""
 fullnameOverride: ""
 

--- a/helm_cnv1_10_1_2/templates/pan-cn-mgmt.yaml
+++ b/helm_cnv1_10_1_2/templates/pan-cn-mgmt.yaml
@@ -36,6 +36,10 @@ spec:
       annotations:
           paloaltonetworks.com/app: pan-mgmt
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: pan-mgmt-sa
       priorityClassName: system-node-critical
       #terminationGracePeriodSeconds: 60 //for graceful exit of prestop hook

--- a/helm_cnv1_10_1_2/templates/pan-cn-ngfw.yaml
+++ b/helm_cnv1_10_1_2/templates/pan-cn-ngfw.yaml
@@ -35,6 +35,10 @@ spec:
           k8s.v1.cni.cncf.io/networks: pan-cni
           {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       priorityClassName: system-cluster-critical
       # Minimize downtime during a rolling upgrade or deletion; Can tell Kubernetes
       # to do a "force deletion": 

--- a/helm_cnv1_10_1_2/templates/pan-cni.yaml
+++ b/helm_cnv1_10_1_2/templates/pan-cni.yaml
@@ -40,6 +40,10 @@ spec:
         {{- end }}
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true

--- a/helm_cnv1_10_1_2/values.yaml
+++ b/helm_cnv1_10_1_2/values.yaml
@@ -79,7 +79,8 @@ secureInterfaces: ["eth0"]
 ############
 # Non essential configs
 ############
-imagePullSecrets: 
+imagePullSecrets: []
+  # - name: myRegistryKeySecretName
 nameOverride: ""
 fullnameOverride: ""
 

--- a/helm_cnv2_10_1/templates/pan-cn-mgmt.yaml
+++ b/helm_cnv2_10_1/templates/pan-cn-mgmt.yaml
@@ -36,6 +36,10 @@ spec:
       annotations:
           paloaltonetworks.com/app: pan-mgmt
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: pan-mgmt-sa
       priorityClassName: system-node-critical
       #terminationGracePeriodSeconds: 60 //for graceful exit of prestop hook

--- a/helm_cnv2_10_1/templates/pan-cn-ngfw.yaml
+++ b/helm_cnv2_10_1/templates/pan-cn-ngfw.yaml
@@ -35,6 +35,10 @@ spec:
           # pan-cni CNI plugin for this pod, otherwise no impact.
           k8s.v1.cni.cncf.io/networks: pan-cni
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       priorityClassName: system-cluster-critical
       # Minimize downtime during a rolling upgrade or deletion; Can tell Kubernetes
       # to do a "force deletion": 

--- a/helm_cnv2_10_1/templates/pan-cni.yaml
+++ b/helm_cnv2_10_1/templates/pan-cni.yaml
@@ -29,6 +29,10 @@ spec:
         paloaltonetworks.com/app: pan-cni
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true

--- a/helm_cnv2_10_1/values.yaml
+++ b/helm_cnv2_10_1/values.yaml
@@ -56,6 +56,7 @@ cni:
 # Non essential configs
 ############
 imagePullSecrets: []
+  # - name: myRegistryKeySecretName
 nameOverride: ""
 fullnameOverride: ""
 

--- a/helm_cnv2_10_1_2/templates/pan-cn-mgmt.yaml
+++ b/helm_cnv2_10_1_2/templates/pan-cn-mgmt.yaml
@@ -36,6 +36,10 @@ spec:
       annotations:
           paloaltonetworks.com/app: pan-mgmt
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: pan-mgmt-sa
       priorityClassName: system-node-critical
       #terminationGracePeriodSeconds: 60 //for graceful exit of prestop hook

--- a/helm_cnv2_10_1_2/templates/pan-cn-ngfw.yaml
+++ b/helm_cnv2_10_1_2/templates/pan-cn-ngfw.yaml
@@ -35,6 +35,10 @@ spec:
           # pan-cni CNI plugin for this pod, otherwise no impact.
           k8s.v1.cni.cncf.io/networks: pan-cni
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       priorityClassName: system-cluster-critical
       # Minimize downtime during a rolling upgrade or deletion; Can tell Kubernetes
       # to do a "force deletion": 

--- a/helm_cnv2_10_1_2/templates/pan-cni.yaml
+++ b/helm_cnv2_10_1_2/templates/pan-cni.yaml
@@ -29,6 +29,10 @@ spec:
         paloaltonetworks.com/app: pan-cni
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true

--- a/helm_cnv2_10_1_2/values.yaml
+++ b/helm_cnv2_10_1_2/values.yaml
@@ -76,6 +76,7 @@ pan_data_mode:
 # Non essential configs
 ############
 imagePullSecrets: []
+  # - name: myRegistryKeySecretName
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
## Description
You can find the `imagePullSecrets` parameter in each of the `values.yml` files but points to nothing in template manifests. It might be confusing to keep it without use.

## Motivation and Context
As per the CN-Series deployment guide (https://docs.paloaltonetworks.com/cn-series/10-0/cn-series-deployment/secure-kubernetes-workloads-with-cn-series/get-the-images-and-files-for-the-cn-series-deployment.html), PANOS Docker images need be downloaded from support.paloaltonetworks.com and push it into a private Docker repository. In most cases, we need to use a private key to access a private Docker registry.

## How Has This Been Tested?
I tested with `helm install ./ -f values.yaml --generate-name` using Helm v3.4.2.

## Screenshots (if appropriate)

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
