### PR TITLE
fix service mode for openshift

### DIFF
--- a/helm_cnv2/pan-cni-net-attach-def.yaml
+++ b/helm_cnv2/pan-cni-net-attach-def.yaml
@@ -1,0 +1,5 @@
+# For OpenShift deploy this with "-n <target-namespace>" for every app pod's namespace
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: pan-cni

--- a/helm_cnv2/templates/pan-cn-mgmt-configmap.yaml
+++ b/helm_cnv2/templates/pan-cn-mgmt-configmap.yaml
@@ -22,9 +22,14 @@ data:
   #CLUSTER_NAME: "<Cluster name>"
 
   #PAN_PANORAMA_IP2: ""
-  # Comment out to use CERTs otherwise PSK for IPSec between pan-mgmt and pan-ngfw
   
+  # Comment out to use CERTs otherwise PSK for IPSec between pan-mgmt and pan-ngfw
+  {{- if eq .Values.cluster.deployTo "openshift" }}
+  # Not using CERTs currently in openshift
+  IPSEC_CERT_BYPASS: ""         # No values needed
+  {{- else }}
   # IPSEC_CERT_BYPASS: ""         # No values needed
+  {{- end }}
   
   {{- if .Values.pan_jumbo_frame_enabled }}
   # Override auto-detect of jumbo-frame mode and force enable system-wide

--- a/helm_cnv2/templates/pan-cn-ngfw-configmap.yaml
+++ b/helm_cnv2/templates/pan-cn-ngfw-configmap.yaml
@@ -10,6 +10,11 @@ data:
   PAN_CTNR_MODE_TYPE: "k8s-service"
   
   # Comment out to use CERTs otherwise PSK for IPSec between pan-mgmt and pan-ngfw
+  {{- if eq .Values.cluster.deployTo "openshift" }}
+  # Not using CERTs currently in openshift
+  IPSEC_CERT_BYPASS: ""             # No values needed
+  {{- else }}
   #IPSEC_CERT_BYPASS: ""            # No values needed
-  
+  {{- end }}
+
   #IPSEC_NAT_PORT_RANGE: "4500-4500"    # port range to avoid stale connections

--- a/helm_cnv2/templates/pan-cn-ngfw.yaml
+++ b/helm_cnv2/templates/pan-cn-ngfw.yaml
@@ -32,10 +32,11 @@ spec:
           #After k8s plugin change, change this to following to avoid confusion:
           #     paloaltonetworks.com/app: pan-ngfw-app
           paloaltonetworks.com/app: pan-fw
-           
+          {{- if eq .Values.cluster.deployTo "openshift" }}           
           # If multus CNI is present, this annotation is needed to enable
           # pan-cni CNI plugin for this pod, otherwise no impact.
           k8s.v1.cni.cncf.io/networks: pan-cni
+          {{- end }}
     spec:
       priorityClassName: system-cluster-critical
       # Minimize downtime during a rolling upgrade or deletion; Can tell Kubernetes
@@ -76,8 +77,9 @@ spec:
           imagePullPolicy: Always
           securityContext:
             capabilities:	
-              add: ["ALL"] 
-              #add: ["NET_ADMIN","NET_RAW","NET_BROADCAST","NET_BIND_SERVICE"] 
+              add: ["ALL"]
+            privileged: true
+            runAsNonRoot: false
           resources:
             requests:
               # configurable based on desired throughput, number of running pods

--- a/helm_cnv2/templates/pan-cni.yaml
+++ b/helm_cnv2/templates/pan-cni.yaml
@@ -1,3 +1,13 @@
+{{- if eq .Values.cluster.deployTo "openshift" }}
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: pan-cni
+  # Defining it in kube-system for pan-ngfw-ds. 
+  # Do this for each namespace where app pod can be run
+  namespace: kube-system      
+---     
+{{- end }}
 # This manifest installs the pan install-cni container, as well
 # as the pan CNI plugin and config on
 # each master and worker node in a Kubernetes cluster.
@@ -64,24 +74,18 @@ spec:
                 configMapKeyRef:
                   name: pan-cni-config
                   key: cni_network_config
+            {{- if eq .Values.cluster.deployTo "openshift" }}
             # Name of the CNI config file for our CNI plugin.
-            #- name: CNI_CONF_NAME
-            {{- if eq .Values.cluster.deployTo "gke" }}
-            #  value: "10-calico.conflist"
-            # 
-            {{- else if eq .Values.cluster.deployTo "eks" }}
-            #  value: "10-aws.conflist"
-            #
-            {{- else if eq .Values.cluster.deployTo "aks" }}
-            #  value: "10-azure.conflist"
+            - name: CNI_CONF_NAME
+              value: "pan-cni.conf"
+            # Name of the directory for CNI config file for our CNI plugin.
+            - name: CNI_NET_DIR
+              value: "/etc/cni/multus/net.d"
+            # Whether to deploy the configuration file as a plugin chain or as
+            # a standalone file (for multus) in cni-conf-dir
+            - name: CHAINED_CNI_PLUGIN
+              value: "false"
             {{- end }}
-            # Name of the primary CNI config file to add our CNI plugin.
-            # This is optional. We always wait until this configured (if
-            # configured) or any cni conf file is detected. If configured
-            # pan-cni will wait until configured CNI conf becomes primary
-            #- name: CNI_CONF_NAME
-            #  value: "10-azure.conflist"
-            #
             # This is optional. After pan-cni insertion, delay for it to be
             # picked up/propogated before makring pan-cni-ready (default 30 seconds)
             #- name: CNI_READY_DELAY
@@ -107,12 +111,18 @@ spec:
           hostPath:
           {{- if eq .Values.cluster.deployTo "gke" }}
             path: /home/kubernetes/bin
+          {{- else if eq .Values.cluster.deployTo "openshift" }}
+            path: /var/lib/cni/bin
           {{- else }}
             path: /opt/cni/bin
             {{- end }}
         - name: cni-net-dir
           hostPath:
+            {{- if eq .Values.cluster.deployTo "openshift" }}
+            path: /etc/cni/multus/net.d
+            {{- else }}
             path: /etc/cni/net.d
+            {{- end }}
         - name: appinfo
           hostPath:
             # app pod info's directory location on host


### PR DESCRIPTION
- helm_cnv2/pan-cni-net-attach-def.yaml so it can be applied for app namespace
- IPSEC_CERT_BYPASS: "" to ngfw and mgmt configmaps as not using cert auth for ipsec currently in openshift
- pan-cni annotation to ngfw
- privileged to ngfw
- openshift multus envs and folders to pan-cni