### PR TITLE
Use mp values for replicas

### DIFF
--- a/helm_cnv2/templates/pan-cn-mgmt.yaml
+++ b/helm_cnv2/templates/pan-cn-mgmt.yaml
@@ -24,7 +24,7 @@ spec:
       appname: pan-mgmt-sts
   serviceName: pan-mgmt-svc
   # Replicas are for fault-tolerance. Max 2 replicas supported.
-  replicas: {{ .Values.dp.max_replicas }}
+  replicas: {{ .Values.mp.max_replicas }}
   updateStrategy:
     type: RollingUpdate
   podManagementPolicy: Parallel


### PR DESCRIPTION
Update helm_cnv2/templates/pan-cn-mgmt.yaml
- correct typo, so .Values.mp.max_replicas is used for replicas and not .Values.dp.max_replicas